### PR TITLE
FIX: Issues in CI

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -13,8 +13,10 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         eval "$(pyenv init -)"
     fi
 
-    pyenv install 3.7.1
-    pyenv virtualenv 3.7.1 conan
+    # Google's depot_tools don't work well with new python versions. For now, we
+    # will use -- the soon to be deprecated -- python 2.7 as a workaround.
+    pyenv install 2.7.16
+    pyenv virtualenv 2.7.16 conan
     pyenv rehash
     pyenv activate conan
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,30 +10,6 @@ osx: &osx
    language: generic
 matrix:
    include:
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,18 +4,6 @@ environment:
     PYTHON_HOME: "C:\\Python37"
 
     matrix:
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Debug
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release

--- a/conanfile.py
+++ b/conanfile.py
@@ -133,7 +133,8 @@ class CrashpadConan(ConanFile):
             self.cpp_info.exelinkflags.append("-framework CoreFoundation")
             self.cpp_info.exelinkflags.append("-framework CoreGraphics")
             self.cpp_info.exelinkflags.append("-framework CoreText")
-            self.cpp_info.exelinkflags.append("-framework Security")
+            self.cpp_info.exelinkflags.append("-framework Foundation")
             self.cpp_info.exelinkflags.append("-framework IOKit")
+            self.cpp_info.exelinkflags.append("-framework Security")
             self.cpp_info.exelinkflags.append("-lbsm")
             self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,3 +1,5 @@
+set (CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+
 project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
 


### PR DESCRIPTION
* properly configure the target architecture (`x86` vs `x86_64`)
* remove Visual Studio 2015 ([not supported by Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md))
* disabled builds on Linux, as Chromium does not fully support it anyway
  * once Google's tooling does not depend on Python 2 anymore, we might give it another shot
* switched the macOS builds to use a python venv based on 2.7 >.<