### PR TITLE
FIX: Xcode11 build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -61,6 +61,8 @@ class CrashpadConan(ConanFile):
         self.run("gclient sync --no-history", run_environment=True)
         tools.patch(base_path=os.path.join(self._source_dir, "third_party/mini_chromium/mini_chromium"),
                     patch_file="patches/dynamic_crt.patch")
+        # Backport of an upstream patch. Once crashpad gets updated to a version containing mini_chromium
+        # later than Aug 29, 2019, this patch can be removed again.
         tools.patch(base_path=os.path.join(self._source_dir, "third_party/mini_chromium/mini_chromium"),
                     patch_file="patches/fix_xcode11.patch")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,6 +61,8 @@ class CrashpadConan(ConanFile):
         self.run("gclient sync --no-history", run_environment=True)
         tools.patch(base_path=os.path.join(self._source_dir, "third_party/mini_chromium/mini_chromium"),
                     patch_file="patches/dynamic_crt.patch")
+        tools.patch(base_path=os.path.join(self._source_dir, "third_party/mini_chromium/mini_chromium"),
+                    patch_file="patches/fix_xcode11.patch")
 
     def _get_target_cpu(self):
         arch = str(self.settings.arch)

--- a/patches/fix_xcode11.patch
+++ b/patches/fix_xcode11.patch
@@ -1,0 +1,198 @@
+diff --git a/base/mac/foundation_util.h b/base/mac/foundation_util.h
+index 9291ac7..fba5d01 100644
+--- a/base/mac/foundation_util.h
++++ b/base/mac/foundation_util.h
+@@ -57,23 +57,23 @@ CFMutable##name##Ref NSToCFCast(NSMutable##name* ns_val); \
+ // List of toll-free bridged types taken from:
+ // http://www.cocoadev.com/index.pl?TollFreeBridged
+ 
+-CF_TO_NS_MUTABLE_CAST_DECL(Array);
+-CF_TO_NS_MUTABLE_CAST_DECL(AttributedString);
+-CF_TO_NS_CAST_DECL(CFCalendar, NSCalendar);
+-CF_TO_NS_MUTABLE_CAST_DECL(CharacterSet);
+-CF_TO_NS_MUTABLE_CAST_DECL(Data);
+-CF_TO_NS_CAST_DECL(CFDate, NSDate);
+-CF_TO_NS_MUTABLE_CAST_DECL(Dictionary);
+-CF_TO_NS_CAST_DECL(CFError, NSError);
+-CF_TO_NS_CAST_DECL(CFLocale, NSLocale);
+-CF_TO_NS_CAST_DECL(CFNumber, NSNumber);
+-CF_TO_NS_CAST_DECL(CFRunLoopTimer, NSTimer);
+-CF_TO_NS_CAST_DECL(CFTimeZone, NSTimeZone);
+-CF_TO_NS_MUTABLE_CAST_DECL(Set);
+-CF_TO_NS_CAST_DECL(CFReadStream, NSInputStream);
+-CF_TO_NS_CAST_DECL(CFWriteStream, NSOutputStream);
+-CF_TO_NS_MUTABLE_CAST_DECL(String);
+-CF_TO_NS_CAST_DECL(CFURL, NSURL);
++CF_TO_NS_MUTABLE_CAST_DECL(Array)
++CF_TO_NS_MUTABLE_CAST_DECL(AttributedString)
++CF_TO_NS_CAST_DECL(CFCalendar, NSCalendar)
++CF_TO_NS_MUTABLE_CAST_DECL(CharacterSet)
++CF_TO_NS_MUTABLE_CAST_DECL(Data)
++CF_TO_NS_CAST_DECL(CFDate, NSDate)
++CF_TO_NS_MUTABLE_CAST_DECL(Dictionary)
++CF_TO_NS_CAST_DECL(CFError, NSError)
++CF_TO_NS_CAST_DECL(CFLocale, NSLocale)
++CF_TO_NS_CAST_DECL(CFNumber, NSNumber)
++CF_TO_NS_CAST_DECL(CFRunLoopTimer, NSTimer)
++CF_TO_NS_CAST_DECL(CFTimeZone, NSTimeZone)
++CF_TO_NS_MUTABLE_CAST_DECL(Set)
++CF_TO_NS_CAST_DECL(CFReadStream, NSInputStream)
++CF_TO_NS_CAST_DECL(CFWriteStream, NSOutputStream)
++CF_TO_NS_MUTABLE_CAST_DECL(String)
++CF_TO_NS_CAST_DECL(CFURL, NSURL)
+ 
+ #undef CF_TO_NS_CAST_DECL
+ #undef CF_TO_NS_MUTABLE_CAST_DECL
+@@ -104,12 +104,12 @@ T CFCast(const CFTypeRef& cf_val);
+ template<typename T>
+ T CFCastStrict(const CFTypeRef& cf_val);
+ 
+-#define CF_CAST_DECL(TypeCF) \
+-template<> TypeCF##Ref \
+-CFCast<TypeCF##Ref>(const CFTypeRef& cf_val);\
+-\
+-template<> TypeCF##Ref \
+-CFCastStrict<TypeCF##Ref>(const CFTypeRef& cf_val);
++#define CF_CAST_DECL(TypeCF)                  \
++template<> TypeCF##Ref                        \
++CFCast<TypeCF##Ref>(const CFTypeRef& cf_val); \
++                                              \
++template<> TypeCF##Ref                        \
++CFCastStrict<TypeCF##Ref>(const CFTypeRef& cf_val)
+ 
+ CF_CAST_DECL(CFArray);
+ CF_CAST_DECL(CFBag);
+diff --git a/base/mac/foundation_util.mm b/base/mac/foundation_util.mm
+index 2c09649..88d8a76 100644
+--- a/base/mac/foundation_util.mm
++++ b/base/mac/foundation_util.mm
+@@ -45,23 +45,23 @@
+   return cf_val; \
+ }
+ 
+-CF_TO_NS_MUTABLE_CAST_DEFN(Array);
+-CF_TO_NS_MUTABLE_CAST_DEFN(AttributedString);
+-CF_TO_NS_CAST_DEFN(CFCalendar, NSCalendar);
+-CF_TO_NS_MUTABLE_CAST_DEFN(CharacterSet);
+-CF_TO_NS_MUTABLE_CAST_DEFN(Data);
+-CF_TO_NS_CAST_DEFN(CFDate, NSDate);
+-CF_TO_NS_MUTABLE_CAST_DEFN(Dictionary);
+-CF_TO_NS_CAST_DEFN(CFError, NSError);
+-CF_TO_NS_CAST_DEFN(CFLocale, NSLocale);
+-CF_TO_NS_CAST_DEFN(CFNumber, NSNumber);
+-CF_TO_NS_CAST_DEFN(CFRunLoopTimer, NSTimer);
+-CF_TO_NS_CAST_DEFN(CFTimeZone, NSTimeZone);
+-CF_TO_NS_MUTABLE_CAST_DEFN(Set);
+-CF_TO_NS_CAST_DEFN(CFReadStream, NSInputStream);
+-CF_TO_NS_CAST_DEFN(CFWriteStream, NSOutputStream);
+-CF_TO_NS_MUTABLE_CAST_DEFN(String);
+-CF_TO_NS_CAST_DEFN(CFURL, NSURL);
++CF_TO_NS_MUTABLE_CAST_DEFN(Array)
++CF_TO_NS_MUTABLE_CAST_DEFN(AttributedString)
++CF_TO_NS_CAST_DEFN(CFCalendar, NSCalendar)
++CF_TO_NS_MUTABLE_CAST_DEFN(CharacterSet)
++CF_TO_NS_MUTABLE_CAST_DEFN(Data)
++CF_TO_NS_CAST_DEFN(CFDate, NSDate)
++CF_TO_NS_MUTABLE_CAST_DEFN(Dictionary)
++CF_TO_NS_CAST_DEFN(CFError, NSError)
++CF_TO_NS_CAST_DEFN(CFLocale, NSLocale)
++CF_TO_NS_CAST_DEFN(CFNumber, NSNumber)
++CF_TO_NS_CAST_DEFN(CFRunLoopTimer, NSTimer)
++CF_TO_NS_CAST_DEFN(CFTimeZone, NSTimeZone)
++CF_TO_NS_MUTABLE_CAST_DEFN(Set)
++CF_TO_NS_CAST_DEFN(CFReadStream, NSInputStream)
++CF_TO_NS_CAST_DEFN(CFWriteStream, NSOutputStream)
++CF_TO_NS_MUTABLE_CAST_DEFN(String)
++CF_TO_NS_CAST_DEFN(CFURL, NSURL)
+ 
+ #undef CF_TO_NS_CAST_DEFN
+ #undef CF_TO_NS_MUTABLE_CAST_DEFN
+@@ -85,26 +85,26 @@
+   return rv; \
+ }
+ 
+-CF_CAST_DEFN(CFArray);
+-CF_CAST_DEFN(CFBag);
+-CF_CAST_DEFN(CFBoolean);
+-CF_CAST_DEFN(CFData);
+-CF_CAST_DEFN(CFDate);
+-CF_CAST_DEFN(CFDictionary);
+-CF_CAST_DEFN(CFNull);
+-CF_CAST_DEFN(CFNumber);
+-CF_CAST_DEFN(CFSet);
+-CF_CAST_DEFN(CFString);
+-CF_CAST_DEFN(CFURL);
+-CF_CAST_DEFN(CFUUID);
++CF_CAST_DEFN(CFArray)
++CF_CAST_DEFN(CFBag)
++CF_CAST_DEFN(CFBoolean)
++CF_CAST_DEFN(CFData)
++CF_CAST_DEFN(CFDate)
++CF_CAST_DEFN(CFDictionary)
++CF_CAST_DEFN(CFNull)
++CF_CAST_DEFN(CFNumber)
++CF_CAST_DEFN(CFSet)
++CF_CAST_DEFN(CFString)
++CF_CAST_DEFN(CFURL)
++CF_CAST_DEFN(CFUUID)
+ 
+-CF_CAST_DEFN(CGColor);
++CF_CAST_DEFN(CGColor)
+ 
+-CF_CAST_DEFN(CTFont);
+-CF_CAST_DEFN(CTRun);
++CF_CAST_DEFN(CTFont)
++CF_CAST_DEFN(CTRun)
+ 
+-CF_CAST_DEFN(SecACL);
+-CF_CAST_DEFN(SecTrustedApplication);
++CF_CAST_DEFN(SecACL)
++CF_CAST_DEFN(SecTrustedApplication)
+ 
+ #undef CF_CAST_DEFN
+ 
+diff --git a/build/BUILD.gn b/build/BUILD.gn
+index 1c5fb09..ca3bba3 100644
+--- a/build/BUILD.gn
++++ b/build/BUILD.gn
+@@ -261,10 +261,6 @@ config("default") {
+     ]
+   }
+ 
+-  if (mini_chromium_is_clang) {
+-    cflags += [ "-Wimplicit-fallthrough" ]
+-  }
+-
+   cflags += common_flags
+   asmflags += common_flags
+   ldflags += common_flags
+@@ -288,6 +284,13 @@ config("Wexit_time_destructors") {
+   }
+ }
+ 
++config("Wimplicit_fallthrough") {
++  if (mini_chromium_is_clang) {
++    cflags = [ "-Wimplicit-fallthrough" ]
++  }
++
++}
++
+ config("win_console") {
+   if (mini_chromium_is_win) {
+     ldflags = [ "/SUBSYSTEM:CONSOLE" ]
+diff --git a/build/common.gypi b/build/common.gypi
+index 45bd0f7..e9359e7 100644
+--- a/build/common.gypi
++++ b/build/common.gypi
+@@ -246,9 +246,9 @@
+         'msvs_disabled_warnings': [
+           4100,  # Unreferenced formal parameter.
+           4127,  # Conditional expression is constant.
++          4324,  # Structure was padded due to alignment specifier.
+           4351,  # New behavior: elements of array will be default initialized.
+-          4530,  # Exceptions are disabled.
+-          4702,  # Unreachable code. https://crbug.com/346399
++          4577,  # 'noexcept' used with no exception handling mode specified.
+           4996,  # 'X' was declared deprecated.
+         ],
+         'defines': [


### PR DESCRIPTION
XCode 11, which will be shipped with macOS 10.15 sometime next month, warned about extranous `;` in some Mac-specific files. This backports an upstream fix from the mini_chromium project to remove those. Once crashpad gets updated, the fix can be removed again.